### PR TITLE
Tasks should include as part of their `Raw` sets of input and output denotations 

### DIFF
--- a/src/main/scala/defaultLocations.scala
+++ b/src/main/scala/defaultLocations.scala
@@ -2,6 +2,7 @@ package era7.projects
 
 import ohnosequences.datasets._
 import ohnosequences.cosas._, types._, fns._, klists._
+import ohnosequences.awstools.s3._
 
 class defaultS3LocationForTask[T <: AnyTask](val task: T) extends DepFn1[
   AnyData,
@@ -11,4 +12,15 @@ class defaultS3LocationForTask[T <: AnyTask](val task: T) extends DepFn1[
 
   implicit def default[D <: AnyData]: AnyApp1At[this.type, D] { type Y = D := S3Resource } =
     App1 { d: D => d := S3Resource(task.s3Output / d.label) }
+}
+
+class insertAfter(val prefix: String, val fragment: String) extends DepFn1[AnyDenotation { type Value = S3Resource }, AnyDenotation { type Value = S3Resource }] {
+
+  implicit def default[D <: AnyData]: AnyApp1At[insertAfter, D := S3Resource] { type Y = D := S3Resource } =
+    App1 { d: D := S3Resource => {
+
+        val rhs = d.value.resource.key.stripPrefix(prefix)
+        d.tpe := S3Resource(S3Object(d.value.resource.bucket, s"${prefix}${fragment}/${rhs}"))
+      }
+    }
 }

--- a/src/test/scala/DefaultLocationsTests.scala
+++ b/src/test/scala/DefaultLocationsTests.scala
@@ -33,13 +33,6 @@ case object example {
     type Output = input.type
     val output = input
   }
-
-  def lll(x: String) = {
-
-    val a = doSomethingParam(x); import a._
-
-    a.input.keys.types map a.defaultS3Location
-  }
 }
 
 class DefaultLocationsTest extends FunSuite {
@@ -57,10 +50,23 @@ class DefaultLocationsTest extends FunSuite {
     assert {
       (doSomething.input.keys.types map doSomething.defaultS3Location) === doSomething.defaultOutputS3Location
     }
-  }
 
-  test("default parametric S3 locations") {
+    val uh = doSomething.defaultOutputS3Location; val pref = new insertAfter(doSomething.s3Output.key, "buh")
 
-    println { List("a", "b", "c") map lll _}
+    import pref._
+
+    val z = uh map pref
+
+    val samples = List("hola", "scalac", "que tal")
+
+    val s3PerSample = samples map {
+      s => {
+        val pref = new insertAfter(doSomething.s3Output.key, s);
+        import pref._
+        uh map pref
+      }
+    }
+
+    println { s3PerSample }
   }
 }

--- a/src/test/scala/exampleProject.scala
+++ b/src/test/scala/exampleProject.scala
@@ -37,8 +37,9 @@ case object ProjectState {
 
   // Now imagine that I already got my rice, but no seafood yet
   val uh = preparePaellaTasks := (
-    (buyRice    := Completed) ::
-    (buySeafood := Specified) :: *[AnyDenotation]
+    ( buyRice     := (Completed :: List(*[AnyDenotation]) :: List(buyRice.defaultOutputS3Location) :: *[Any]) )   ::
+    ( buySeafood  := (Specified :: List(*[AnyDenotation]) :: List(buySeafood.defaultOutputS3Location) :: *[Any]) ) ::
+    *[AnyDenotation]
   )
 }
 
@@ -50,7 +51,7 @@ abstract class GenericTasksTests[
 
   test("dummy test with tasks") {
 
-    println { pt.keys.types.asList toString }
+    // println { pt.keys.types.asList toString }
   }
 }
 


### PR DESCRIPTION
For `AnyTask`, we should have something like

``` scala
trait AnyTask {
  type Raw <: AnyTaskState :: List[Input#Raw] :: List[Output#Raw] :: *[Any]
}
```

or something with an intermediate datatype for a set of denotations of a dataset.
