### PR TITLE
getting a set of default locations for a dataset

### DIFF
--- a/src/main/scala/defaultLocations.scala
+++ b/src/main/scala/defaultLocations.scala
@@ -14,9 +14,15 @@ class defaultS3LocationForTask[T <: AnyTask](val task: T) extends DepFn1[
     App1 { d: D => d := S3Resource(task.s3Output / d.label) }
 }
 
-class insertAfter(val prefix: String, val fragment: String) extends DepFn1[AnyDenotation { type Value = S3Resource }, AnyDenotation { type Value = S3Resource }] {
+// TODO should fragment be a S3 folder?
+case class insertAfter(val prefix: String, val fragment: String) extends DepFn1[
+  AnyDenotation { type Value = S3Resource },
+  AnyDenotation { type Value = S3Resource }
+]
+{
 
-  implicit def default[D <: AnyData]: AnyApp1At[insertAfter, D := S3Resource] { type Y = D := S3Resource } =
+  implicit def default[D <: AnyData]
+  : AnyApp1At[insertAfter, D := S3Resource] { type Y = D := S3Resource } =
     App1 { d: D := S3Resource => {
 
         val rhs = d.value.resource.key.stripPrefix(prefix)

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -1,0 +1,9 @@
+package era7
+
+import ohnosequences.cosas.types._
+import ohnosequences.datasets._
+
+package object projects {
+
+  val noData: |[AnyData] = |[AnyData]
+}

--- a/src/main/scala/projects.scala
+++ b/src/main/scala/projects.scala
@@ -102,21 +102,51 @@ trait AnyTask extends AnyType {
 
   val deadline: java.util.Date
 }
-/*
-  This is a helper constructor for doing `case object doSometing extends Task(project)(name)`
-*/
 
-abstract class Task[P <: AnyProject](val project: P)(val deadline: java.util.Date) extends AnyTask {
+// abstract class Task[P <: AnyProject](val project: P)(val deadline: java.util.Date) extends AnyTask {
+//
+//   type Project = P
+//
+//   lazy val name: String = toString
+// }
+
+/*
+  This is a helper constructor for doing  something like
+
+  ``` scala
+  case object doSomething extends Task(project)(input)(output)(date)`
+  ```
+*/
+class Task[
+  P <: AnyProject,
+  I <: AnyProductType { type Types <: AnyKList.Of[AnyData] },
+  O <: AnyProductType { type Types <: AnyKList.Of[AnyData] }
+](
+  val project: P
+)(
+  val inputData: I
+)(
+  val outputData: O
+)(
+  val deadline: java.util.Date
+)(
+  implicit
+    proof1: noDuplicates isTrueOn I#Types,
+    proof2: noDuplicates isTrueOn O#Types
+)
+extends AnyTask {
 
   type Project = P
+
+  type Input = DataSet[I]
+  lazy val input: Input = new DataSet(inputData) {}
+
+  type Output = DataSet[O]
+  lazy val output: Output = new DataSet(outputData) {}
 
   lazy val name: String = toString
 }
 
-case class TaskSyntax[T <: AnyTask](val task: T) extends AnyVal {
-
-  // def
-}
 
 sealed trait AnyTaskState
 

--- a/src/main/scala/projects.scala
+++ b/src/main/scala/projects.scala
@@ -84,7 +84,10 @@ trait AnyTask extends AnyType {
     This is a depfn which when applied on data: `task.defaultS3Location(d)` yields the default S3 location for `d`. You can use it for building data Loquat data mappings, for example, by mapping over the types of the input/output records.
   */
   case object defaultS3Location extends defaultS3LocationForTask(this)
-  
+
+  /* the returned depfn will let you add a qualifier after the standard output path for this task. See the tests for an example of its use */
+  def defaultLocationWithQualifier(qual: String): insertAfter = insertAfter(s3Output.key, qual)
+
   def defaultOutputS3Location[
     O <: Output#Raw
   ](implicit

--- a/src/test/scala/DefaultLocationsTests.scala
+++ b/src/test/scala/DefaultLocationsTests.scala
@@ -9,30 +9,11 @@ import era7.projects._
 case object example {
 
   case class Sample(id: String)
+  case object x extends FileData("x")("txt")
 
   case object buh extends era7.projects.Project("buh")
 
-  case object doSomething extends Task(buh)(new java.util.Date) {
-
-    case object x extends FileData("x")("txt")
-
-    case object Input extends DataSet(x :×: |[AnyData])
-    type Input = Input.type
-    val input = Input
-    type Output = input.type
-    val output = input
-  }
-
-  case class doSomethingParam(b: String) extends Task(buh)(new java.util.Date) {
-
-    case object x extends FileData("x")("txt")
-
-    case object Input extends DataSet(x :×: |[AnyData])
-    type Input = Input.type
-    val input = Input
-    type Output = input.type
-    val output = input
-  }
+  case object doSomething extends Task(buh)(x :×: |[AnyData])(x :×: |[AnyData])(new java.util.Date)
 }
 
 class DefaultLocationsTest extends FunSuite {
@@ -43,7 +24,7 @@ class DefaultLocationsTest extends FunSuite {
 
     assert {
       (doSomething.input.keys.types map doSomething.defaultS3Location) === (
-        (doSomething.x := S3Resource(doSomething.s3Output / doSomething.x.label)) :: *[AnyDenotation]
+        (x := S3Resource(doSomething.s3Output / x.label)) :: *[AnyDenotation]
       )
     }
 
@@ -59,7 +40,7 @@ class DefaultLocationsTest extends FunSuite {
 
     val s3PerSample = samples map {
       s => {
-        
+
         val addSamplePrefix = doSomething.defaultLocationWithQualifier(s)
         import addSamplePrefix._
 

--- a/src/test/scala/DefaultLocationsTests.scala
+++ b/src/test/scala/DefaultLocationsTests.scala
@@ -50,20 +50,20 @@ class DefaultLocationsTest extends FunSuite {
     assert {
       (doSomething.input.keys.types map doSomething.defaultS3Location) === doSomething.defaultOutputS3Location
     }
+  }
 
-    val uh = doSomething.defaultOutputS3Location; val pref = new insertAfter(doSomething.s3Output.key, "buh")
+  test("can map over default locations") {
 
-    import pref._
-
-    val z = uh map pref
-
-    val samples = List("hola", "scalac", "que tal")
+    // NOTE just something which serves as a classifier for different denotations of the same resource
+    val samples = Set("hola", "scalac", "que tal")
 
     val s3PerSample = samples map {
       s => {
-        val pref = new insertAfter(doSomething.s3Output.key, s);
-        import pref._
-        uh map pref
+        
+        val addSamplePrefix = doSomething.defaultLocationWithQualifier(s)
+        import addSamplePrefix._
+
+        doSomething.defaultOutputS3Location map addSamplePrefix
       }
     }
 

--- a/src/test/scala/exampleProject.scala
+++ b/src/test/scala/exampleProject.scala
@@ -14,24 +14,19 @@ case object preparePaellaTasks extends ProjectTasks(preparePaella)(
 case object rice    extends Data("La Fallera")
 case object seafood extends Data("Preparado de Paella Pescanova")
 
-case object buyRice extends Task(preparePaella)(new java.util.Date()) {
+case object buyRice extends Task(preparePaella)(noData)(rice :×: |[AnyData])(new java.util.Date())
+//
+// case object buyRice extends Task(preparePaella)(new java.util.Date()) {
+//
+//   // TODO if this style works OK, we can create the record type at the level of AnyTask
+//   type Input  = RecordType[|[AnyData]]
+//   val input   = new RecordType(|[AnyData])
+//
+//   type Output = RecordType[rice.type :×: |[AnyData]]
+//   val output  = new RecordType(rice :×: |[AnyData])
+// }
 
-  // TODO if this style works OK, we can create the record type at the level of AnyTask
-  type Input  = RecordType[|[AnyData]]
-  val input   = new RecordType(|[AnyData])
-
-  type Output = RecordType[rice.type :×: |[AnyData]]
-  val output  = new RecordType(rice :×: |[AnyData])
-}
-
-case object buySeafood extends Task(preparePaella)(new java.util.Date()) {
-
-  type Input  = RecordType[|[AnyData]]
-  val input   = new RecordType(|[AnyData])
-
-  type Output = RecordType[seafood.type :×: |[AnyData]]
-  val output  = new RecordType(seafood :×: |[AnyData])
-}
+case object buySeafood extends Task(preparePaella)(noData)(seafood :×: |[AnyData])(new java.util.Date())
 
 case object ProjectState {
 

--- a/src/test/scala/exampleProject.scala
+++ b/src/test/scala/exampleProject.scala
@@ -15,28 +15,19 @@ case object rice    extends Data("La Fallera")
 case object seafood extends Data("Preparado de Paella Pescanova")
 
 case object buyRice extends Task(preparePaella)(noData)(rice :×: |[AnyData])(new java.util.Date())
-//
-// case object buyRice extends Task(preparePaella)(new java.util.Date()) {
-//
-//   // TODO if this style works OK, we can create the record type at the level of AnyTask
-//   type Input  = RecordType[|[AnyData]]
-//   val input   = new RecordType(|[AnyData])
-//
-//   type Output = RecordType[rice.type :×: |[AnyData]]
-//   val output  = new RecordType(rice :×: |[AnyData])
-// }
-
 case object buySeafood extends Task(preparePaella)(noData)(seafood :×: |[AnyData])(new java.util.Date())
 
-case object ProjectState {
+case object projectState {
 
   // Now imagine that I already got my rice, but no seafood yet
-  val uh = preparePaellaTasks := (
-    ( buyRice     := (Completed :: List(*[AnyDenotation]) :: List(buyRice.defaultOutputS3Location) :: *[Any]) )   ::
-    ( buySeafood  := (Specified :: List(*[AnyDenotation]) :: List(buySeafood.defaultOutputS3Location) :: *[Any]) ) ::
+  val current = preparePaellaTasks := {
+    buyRice( Completed :: List(*[AnyDenotation]) :: List(buyRice.defaultOutputS3Location) :: *[Any] )         ::
+    buySeafood( Specified :: List(*[AnyDenotation]) :: List(buySeafood.defaultOutputS3Location) :: *[Any] )   ::
     *[AnyDenotation]
-  )
+  }
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 abstract class GenericTasksTests[
   P <: AnyProject,


### PR DESCRIPTION
When writing input and outputs for a task, their locations are normally derived from a function `Ctx => String` which provides a suffix to the default task-relative path, adding the data label as a suffix. I'm adding a depfn which does exactly this. 
